### PR TITLE
Declare chokidar optional dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -83,5 +83,8 @@
     "path-to-regexp": "^8.2.0",
     "socket.io": "^4.8.1",
     "zod": "3.24.2"
+  },
+  "optionalDependencies": {
+    "chokidar": "^4.0.3"
   }
 }

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,6 +1,5 @@
 import { buildProject, handleError, isMonorepoContext, UserEnvironment } from '@/src/utils';
 import { Command, Option } from 'commander';
-import { execa } from 'execa';
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
@@ -163,24 +162,18 @@ async function determineProjectType(): Promise<{ isProject: boolean; isPlugin: b
  * Sets up file watching for the given directory
  */
 async function watchDirectory(dir: string, onChange: () => void): Promise<void> {
-  // First check if chokidar is installed
+  let chokidar: typeof import('chokidar');
   try {
-    await execa('npm', ['list', 'chokidar'], { stdio: 'ignore', reject: false });
-  } catch (error) {
-    // If chokidar isn't installed, install it
-    console.info('Installing chokidar dependency for file watching...');
-    try {
-      await execa('npm', ['install', 'chokidar', '--no-save'], { stdio: 'inherit' });
-    } catch (installError) {
-      console.error(`Failed to install chokidar: ${installError.message}`);
-      return;
-    }
+    // Dynamically import chokidar
+    chokidar = await import('chokidar');
+  } catch (error: any) {
+    console.error(
+      'File watching requires the "chokidar" package. Please install it with "npm install chokidar".'
+    );
+    return;
   }
 
   try {
-    // Dynamically import chokidar
-    const chokidar = await import('chokidar');
-
     // Get the absolute path of the directory
     const absoluteDir = path.resolve(dir);
     console.info(`Setting up file watching for directory: ${absoluteDir}`);


### PR DESCRIPTION
## Summary
- mark chokidar as optional dependency for the CLI package
- drop automatic npm install logic
- load chokidar dynamically and show helpful error when missing

## Testing
- `npx prettier --check packages/cli/src/commands/dev.ts packages/cli/package.json`
